### PR TITLE
Fixes issue where ldap_settings being None would break jinja template

### DIFF
--- a/widgets_collection/templates/widgets/login/js/widget.js
+++ b/widgets_collection/templates/widgets/login/js/widget.js
@@ -64,7 +64,7 @@ login.bind_events = function() {
 
 	$(".btn-ldpa-login").on("click", function(){
 		var args = {};
-		args.cmd = "{{ ldap_settings.method }}";
+		args.cmd = "{{ "" if not ldap_settings else ldap_settings.method }}";
 		args.usr = ($("#login_email").val() || "").trim();
 		args.pwd = $("#login_password").val();
 		args.device = "desktop";


### PR DESCRIPTION
Future proofing login widget. Newest version of frappe/erpnext breaks widget js template when ldap_settings isn't set.